### PR TITLE
Add Sonata non-SCC

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -15,6 +15,7 @@ class CAR:
   IONIQ = "HYUNDAI IONIQ HYBRID 2017 PREMIUM"
   KIA_FORTE = "KIA FORTE E 2018"
   ELANTRA_GT_I30 = "HYUNDAI I30 N LINE 2019 & GT 2018 DCT"
+  SONATA_NON_SCC = "HYUNDAI SONATA ECO 2018 NON-SCC"
 
 class Buttons:
   NONE = 0
@@ -89,6 +90,9 @@ FINGERPRINTS = {
   {
     66: 8, 67: 8, 68: 8, 127: 8, 128: 8, 129: 8, 273: 8, 274: 8, 275: 8, 339: 8, 354: 3, 356: 4, 399: 8, 512: 6, 544: 8, 593: 8, 608: 8, 688: 5, 790: 8, 809: 8, 832: 8, 897: 8, 899: 8, 902: 8, 903: 8, 905: 8, 909: 8, 916: 8, 1040: 8, 1056: 8, 1057: 8, 1078: 4, 1151: 6, 1168: 7, 1170: 8, 1265: 4, 1280: 1, 1282: 4, 1287: 4, 1290: 8, 1292: 8, 1294: 8, 1312: 8, 1322: 8, 1342: 6, 1345: 8, 1348: 8, 1349: 8, 1351: 8, 1353: 8, 1356: 8, 1363: 8, 1366: 8, 1367: 8, 1369: 8, 1407: 8, 1414: 3, 1419: 8, 1427: 6, 1440: 8, 1456: 4, 1470: 8, 1486: 8, 1487: 8, 1491: 8, 1960: 8, 1990: 8, 1998: 8, 2000: 8, 2001: 8, 2004: 8, 2005: 8, 2008: 8, 2009: 8, 2012: 8, 2013: 8, 2015: 8, 2016: 8, 2017: 8, 2024: 8, 2025: 8
   }],
+  CAR.SONATA_NON_SCC: [{
+    64: 8, 66: 8, 67: 8, 68: 8, 127: 8, 128: 8, 129: 8, 273: 8, 274: 8, 275: 8, 339: 8, 354: 3, 356: 4, 399: 8, 512: 6, 544: 8, 593: 8, 608: 8, 688: 5, 790: 8, 809: 8, 897: 8, 899: 8, 902: 8, 903: 6, 1040: 8, 1078: 4, 1170: 8, 1265: 4, 1280: 1, 1282: 4, 1287: 4, 1292: 8, 1312: 8, 1314: 8, 1322: 8, 1345: 8, 1349: 8, 1351: 8, 1356: 8, 1363: 8, 1365: 8, 1366: 8, 1367: 8, 1369: 8, 1414: 3, 1415: 8, 1419: 8, 1427: 8, 1440: 8, 1456: 4, 1472: 8, 1491: 8, 1492: 8, 1530: 8, 1532: 5, 2001: 8, 2004: 8, 2006: 8, 2009: 8, 2012: 8, 2014: 8, 2016: 8, 2017: 8, 2024: 8, 2025: 8
+  }],  
 }
 
 class ECU:
@@ -107,7 +111,7 @@ FEATURES = {
   "use_cluster_gears": [CAR.ELANTRA, CAR.KONA, CAR.ELANTRA_GT_I30],     # Use Cluster for Gear Selection, rather than Transmission
   "use_tcu_gears": [CAR.KIA_OPTIMA],                                    # Use TCU Message for Gear Selection
   "use_new_gears": [CAR.KIA_OPTIMA_H],                                  # Use TCU Message for Gear Selection
-  "non_scc": [CAR.IONIQ, CAR.KONA, CAR.KIA_FORTE, CAR.SANTA_FE_1],      # Car without SCC
+  "non_scc": [CAR.IONIQ, CAR.KONA, CAR.KIA_FORTE, CAR.SANTA_FE_1, CAR.SONATA_NON_SCC],      # Car without SCC
 }
 
 DBC = {
@@ -125,6 +129,7 @@ DBC = {
   CAR.KONA: dbc_dict('hyundai_kia_generic', None),
   CAR.KIA_FORTE: dbc_dict('hyundai_kia_generic', None),
   CAR.ELANTRA_GT_I30: dbc_dict('hyundai_kia_generic', None),
+  CAR.SONATA_NON_SCC: dbc_dict('hyundai_kia_generic', None),
 }
 
 STEER_THRESHOLD = 100


### PR DESCRIPTION
Added a 2015 Sonata Eco non-SCC non-LKAS. Added a new car type, a new working fingerprint, and listed it in the non_scc section. I also pointed it to the standard DBC.