### PR TITLE
enable OP steer with set button on non OP long

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -331,10 +331,10 @@ class CarInterface(CarInterfaceBase):
 
   # handle button presses
     for b in ret.buttonEvents:
-      # do disable on button down
-      if b.type == ButtonType.cancel and b.pressed:
-        events.add(EventName.buttonCancel)
       if self.CC.longcontrol and not self.CC.scc_live:
+        # do disable on button down
+        if b.type == ButtonType.cancel and b.pressed:
+          events.add(EventName.buttonCancel)
         # do enable on both accel and decel buttons
         if b.type in [ButtonType.accelCruise, ButtonType.decelCruise] and not b.pressed:
           events.add(EventName.buttonEnable)

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -334,10 +334,10 @@ class CarInterface(CarInterfaceBase):
       # do enable on both accel and decel buttons
       if b.type in [ButtonType.accelCruise, ButtonType.decelCruise] and not b.pressed and ret.cruiseState.enabled:
         events.add(EventName.buttonEnable)
+      # do disable on button down
+      if b.type == ButtonType.cancel and b.pressed:
+        events.add(EventName.buttonCancel)  
       if self.CC.longcontrol and not self.CC.scc_live:
-        # do disable on button down
-        if b.type == ButtonType.cancel and b.pressed:
-          events.add(EventName.buttonCancel)
         if EventName.wrongCarMode in events.events:
           events.events.remove(EventName.wrongCarMode)
         if EventName.pcmDisable in events.events:

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -332,7 +332,7 @@ class CarInterface(CarInterfaceBase):
   # handle button presses
     for b in ret.buttonEvents:
       # do enable on both accel and decel buttons
-      if b.type in [ButtonType.accelCruise, ButtonType.decelCruise] and not b.pressed:
+      if b.type in [ButtonType.accelCruise, ButtonType.decelCruise] and not b.pressed and ret.cruiseState.enabled:
         events.add(EventName.buttonEnable)
       if self.CC.longcontrol and not self.CC.scc_live:
         # do disable on button down

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -331,13 +331,13 @@ class CarInterface(CarInterfaceBase):
 
   # handle button presses
     for b in ret.buttonEvents:
+              # do enable on both accel and decel buttons
+      if b.type in [ButtonType.accelCruise, ButtonType.decelCruise] and not b.pressed:
+        events.add(EventName.buttonEnable)
       if self.CC.longcontrol and not self.CC.scc_live:
         # do disable on button down
         if b.type == ButtonType.cancel and b.pressed:
           events.add(EventName.buttonCancel)
-        # do enable on both accel and decel buttons
-        if b.type in [ButtonType.accelCruise, ButtonType.decelCruise] and not b.pressed:
-          events.add(EventName.buttonEnable)
         if EventName.wrongCarMode in events.events:
           events.events.remove(EventName.wrongCarMode)
         if EventName.pcmDisable in events.events:

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -331,17 +331,21 @@ class CarInterface(CarInterfaceBase):
 
   # handle button presses
     for b in ret.buttonEvents:
-      # do enable on both accel and decel buttons
-      if b.type in [ButtonType.accelCruise, ButtonType.decelCruise] and not b.pressed and ret.cruiseState.enabled:
-        events.add(EventName.buttonEnable)
       # do disable on button down
       if b.type == ButtonType.cancel and b.pressed:
-        events.add(EventName.buttonCancel)  
+        events.add(EventName.buttonCancel)
       if self.CC.longcontrol and not self.CC.scc_live:
+        # do enable on both accel and decel buttons
+        if b.type in [ButtonType.accelCruise, ButtonType.decelCruise] and not b.pressed:
+          events.add(EventName.buttonEnable)
         if EventName.wrongCarMode in events.events:
           events.events.remove(EventName.wrongCarMode)
         if EventName.pcmDisable in events.events:
           events.events.remove(EventName.pcmDisable)
+      elif not self.CC.longcontrol and ret.cruiseState.enabled:
+        # do enable on decel button only
+        if b.type == ButtonType.decelCruise and not b.pressed:
+          events.add(EventName.buttonEnable)
 
     ret.events = events.to_msg()
 

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -331,7 +331,7 @@ class CarInterface(CarInterfaceBase):
 
   # handle button presses
     for b in ret.buttonEvents:
-              # do enable on both accel and decel buttons
+      # do enable on both accel and decel buttons
       if b.type in [ButtonType.accelCruise, ButtonType.decelCruise] and not b.pressed:
         events.add(EventName.buttonEnable)
       if self.CC.longcontrol and not self.CC.scc_live:


### PR DESCRIPTION
For non OP long vehicles-(stock SCC or normal cruise)
OP steer should enable/disable with cruise on/off button
OP steer should not cancel with cruise "cancel" button( this is only recommended for OP long vehicles)