### PR TITLE
Add Kia Niro EV 2020 (model sold in western canada).

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -401,6 +401,7 @@ FW_VERSIONS = {
     (Ecu.fwdRadar, 0x7D0, None): [
       b'\xf1\x00DEev SCC F-CUP      1.00 1.03 96400-Q4100         \xf1\xa01.03',
       b'\xf1\x00DEev SCC F-CUP      1.00 1.00 99110-Q4000         \xf1\xa01.00',
+      b'\xf1\x8799110Q4100\xf1\x00DEev SCC F-CUP      1.00 1.00 99110-Q4100         \xf1\xa01.00',
     ],
     (Ecu.esp, 0x7D1, None): [
       b'\xf1\xa01.06',
@@ -413,6 +414,7 @@ FW_VERSIONS = {
     (Ecu.fwdCamera, 0x7C4, None): [
       b'\xf1\x00DEE MFC  AT USA LHD 1.00 1.03 95740-Q4000 180821',
       b'\xf1\x00DEE MFC  AT EUR LHD 1.00 1.00 99211-Q4000 191211',
+      b'\xf1\x00DEE MFC  AT USA LHD 1.00 1.00 99211-Q4000 191211',
     ],
   },
 }


### PR DESCRIPTION
carFw = [
      ( ecu = fwdRadar,
        fwVersion = "\xf1\x8799110Q4100\xf1\x00DEev SCC F-CUP      1.00 1.00 99110-Q4100         \xf1\xa01.00",
        address = 2000,
        subAddress = 0 ),
      ( ecu = esp,
        fwVersion = "\xf1\xa01.07",
        address = 2001,
        subAddress = 0 ),
      ( ecu = eps,
        fwVersion = "\xf1\x00DE  MDPS C 1.00 1.05 56310Q4000\x00 4DEEC105",
        address = 2004,
        subAddress = 0 ),
      ( ecu = fwdCamera,
        fwVersion = "\xf1\x00DEE MFC  AT USA LHD 1.00 1.00 99211-Q4000 191211",
        address = 1988,
        subAddress = 0 ) ],